### PR TITLE
Added zulu.Datetime.span, zulu.Datetime.start_of and zulu.Datetime.end_of methods

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -107,6 +107,52 @@ Or replace datetime attributes:
 
 .. note:: Since ``DateTime`` is meant to be immutable, both ``shift`` and ``replace`` return new ``DateTime`` instances while leaving the original instance unchanged.
 
+You can get the time span of any unit:
+
+.. code-block:: python
+
+    dt = DateTime(2015, 4, 4, 12, 30)
+    dt.span('century')
+    # (<DateTime [2000-01-01T00:00:00+00:00]>, <DateTime [2099-12-31T23:59:59.999999+00:00]>)
+
+    dt.span('decade')
+    # (<DateTime [2010-01-01T00:00:00+00:00]>, <DateTime [2019-12-31T23:59:59.999999+00:00]>)
+
+    dt.span('year')
+    # (<DateTime [2015-01-01T00:00:00+00:00]>, <DateTime [2015-12-31T23:59:59.999999+00:00]>)
+
+    dt.span('century', count=3)
+    # (<DateTime [2000-01-01T00:00:00+00:00]>, <DateTime [2299-12-31T23:59:59.999999+00:00]>)
+
+    dt.span('decade', count=3)
+    # (<DateTime [2010-01-01T00:00:00+00:00]>, <DateTime [2039-12-31T23:59:59.999999+00:00]>)
+
+
+Or you can also get the start and end of any unit:
+
+.. code-block:: python
+
+    dt = DateTime(2015, 4, 4, 12, 30)
+    dt.start_of('century')
+    # <DateTime [2000-01-01T00:00:00+00:00]>
+
+    dt.start_of('decade')
+    # <DateTime [2010-01-01T00:00:00+00:00]>
+
+    dt.start_of('year')
+    # <DateTime [2015-01-01T00:00:00+00:00]>
+
+    dt.end_of('century')
+    # <DateTime [2099-12-31T23:59:59.999999+00:00]>
+
+    dt.end_of('decade')
+    # <DateTime [2019-12-31T23:59:59.999999+00:00]>
+
+    dt.end_of('year', count=3)
+    # <DateTime [2017-12-31T23:59:59.999999+00:00]>
+
+
+.. note:: Supported units are ``century``, ``decade``, ``year``, ``month``, ``day``, ``hour``, ``minute``, ``second``.
 
 Time zones other than UTC are not expressable within a ``DateTime`` instance. Other time zones are only ever applied when either casting a ``DateTime`` object as a native datetime (via ``DateTime.astimezone``) or during string formatting (via ``DateTime.format``). ``DateTime`` understands both ``tzinfo`` objects and ``pytz.timezone`` strings.
 

--- a/tests/test_zulu.py
+++ b/tests/test_zulu.py
@@ -515,3 +515,69 @@ def test_compare_greater_than(dt, other, expected):
 ])
 def test_compare_greater_than_equal(dt, other, expected):
     assert (dt >= other) is expected
+
+
+@parametrize('dt,span,count,expected', [
+    (DateTime(2015, 4, 4, 12, 30),
+     'century',
+     1,
+     (DateTime(2000, 1, 1, 0, 0),
+      DateTime(2099, 12, 31, 23, 59, 59, 999999))),
+    (DateTime(2015, 4, 4, 12, 30),
+     'decade',
+     1,
+     (DateTime(2010, 1, 1, 0, 0),
+      DateTime(2019, 12, 31, 23, 59, 59, 999999))),
+    (DateTime(2015, 4, 4, 12, 30),
+     'century',
+     3,
+     (DateTime(2000, 1, 1, 0, 0),
+      DateTime(2299, 12, 31, 23, 59, 59, 999999))),
+    (DateTime(2015, 4, 4, 12, 30),
+     'decade',
+     3,
+     (DateTime(2010, 1, 1, 0, 0),
+      DateTime(2039, 12, 31, 23, 59, 59, 999999))),
+    (DateTime(2015, 4, 4, 12, 30),
+     'year',
+     1,
+     (DateTime(2015, 1, 1, 0, 0),
+      DateTime(2015, 12, 31, 23, 59, 59, 999999))),
+    (DateTime(2015, 4, 4, 12, 30),
+     'month',
+     1,
+     (DateTime(2015, 4, 1, 0, 0),
+      DateTime(2015, 4, 30, 23, 59, 59, 999999))),
+    (DateTime(2015, 4, 4, 12, 30),
+     'day',
+     3,
+     (DateTime(2015, 4, 4, 0, 0),
+      DateTime(2015, 4, 6, 23, 59, 59, 999999))),
+    (DateTime(2015, 4, 4, 12, 30),
+     'hour',
+     2,
+     (DateTime(2015, 4, 4, 12, 0),
+      DateTime(2015, 4, 4, 13, 59, 59, 999999))),
+    (DateTime(2015, 4, 4, 12, 30),
+     'minute',
+     5,
+     (DateTime(2015, 4, 4, 12, 30, 0),
+      DateTime(2015, 4, 4, 12, 34, 59, 999999))),
+    (DateTime(2015, 4, 4, 12, 30, 47),
+     'second',
+     20,
+     (DateTime(2015, 4, 4, 12, 30, 47, 0),
+      DateTime(2015, 4, 4, 12, 31, 6, 999999)))
+])
+def test_span(dt, span, count, expected):
+    time_span_tuple = dt.span(span, count)
+    assert time_span_tuple == expected
+
+
+def test_span_attribute_error():
+    frame = 'temp'
+    dt = DateTime(2015, 4, 4, 12, 30)
+    with pytest.raises(ValueError) as exc:
+        dt.span(frame)
+
+    assert 'The given time frame {0} is invalid'.format(frame) in str(exc)

--- a/zulu/datetime.py
+++ b/zulu/datetime.py
@@ -379,6 +379,191 @@ class DateTime(datetime):
 
         return DateTime(*args)
 
+    def start_of_century(self):
+        """This method helps in shifting the values to start of the century."""
+        return self.shift(years=-(self.year % 100),
+                          months=-self.month + 1,
+                          days=-self.day + 1,
+                          hours=-self.hour,
+                          minutes=-self.minute,
+                          seconds=-self.second,
+                          microseconds=-self.microsecond)
+
+    def start_of_decade(self):
+        """This method helps in shifting the values to start of the decade."""
+        return self.shift(years=-(self.year % 10),
+                          months=-self.month + 1,
+                          days=-self.day + 1,
+                          hours=-self.hour,
+                          minutes=-self.minute,
+                          seconds=-self.second,
+                          microseconds=-self.microsecond)
+
+    def start_of_year(self):
+        """This method helps in shifting the values to start of the year."""
+        return self.shift(months=-self.month + 1,
+                          days=-self.day + 1,
+                          hours=-self.hour,
+                          minutes=-self.minute,
+                          seconds=-self.second,
+                          microseconds=-self.microsecond)
+
+    def start_of_month(self):
+        """This method helps in shifting the values to start of the month."""
+        return self.shift(days=-self.day + 1,
+                          hours=-self.hour,
+                          minutes=-self.minute,
+                          seconds=-self.second,
+                          microseconds=-self.microsecond)
+
+    def start_of_day(self):
+        """This method helps in shifting the values to start of the day."""
+        return self.shift(hours=-self.hour,
+                          minutes=-self.minute,
+                          seconds=-self.second,
+                          microseconds=-self.microsecond)
+
+    def start_of_hour(self):
+        """This method helps in shifting the values to start of the hour."""
+        return self.shift(minutes=-self.minute,
+                          seconds=-self.second,
+                          microseconds=-self.microsecond)
+
+    def start_of_minute(self):
+        """This method helps in shifting the values to start of the minute."""
+        return self.shift(seconds=-self.second,
+                          microseconds=-self.microsecond)
+
+    def start_of_second(self):
+        """This method helps in shifting the values to start of the second."""
+        return self.shift(microseconds=-self.microsecond)
+
+    def end_of_century(self, count):
+        """This method helps in shifting the values to end of the century."""
+        return self.shift(years=-(self.year % 100) + (count * 100),
+                          months=-self.month + 1,
+                          days=-self.day + 1,
+                          hours=-self.hour,
+                          minutes=-self.minute,
+                          seconds=-self.second,
+                          microseconds=-1)
+
+    def end_of_decade(self, count):
+        """This method helps in shifting the values to end of the decade."""
+        return self.shift(years=-(self.year % 10) + (count * 10),
+                          months=-self.month + 1,
+                          days=-self.day + 1,
+                          hours=-self.hour,
+                          minutes=-self.minute,
+                          seconds=-self.second,
+                          microseconds=-1)
+
+    def end_of_year(self, count):
+        """This method helps in shifting the values to end of the year."""
+        return self.shift(years=count * 1,
+                          months=-self.month + 1,
+                          days=-self.day + 1,
+                          hours=-self.hour,
+                          minutes=-self.minute,
+                          seconds=-self.second,
+                          microseconds=-1)
+
+    def end_of_month(self, count):
+        """This method helps in shifting the values to end of the month."""
+        return self.shift(months=count * 1,
+                          days=-self.day + 1,
+                          hours=-self.hour,
+                          minutes=-self.minute,
+                          seconds=-self.second,
+                          microseconds=-1)
+
+    def end_of_day(self, count):
+        """This method helps in shifting the values to end of the day."""
+        return self.shift(days=count * 1,
+                          hours=-self.hour,
+                          minutes=-self.minute,
+                          seconds=-self.second,
+                          microseconds=-1)
+
+    def end_of_hour(self, count):
+        """This method helps in shifting the values to end of the hour."""
+        return self.shift(hours=count * 1,
+                          minutes=-self.minute,
+                          seconds=-self.second,
+                          microseconds=-1)
+
+    def end_of_minute(self, count):
+        """This method helps in shifting the values to end of the minute."""
+        return self.shift(minutes=count * 1,
+                          seconds=-self.second,
+                          microseconds=-1)
+
+    def end_of_second(self, count):
+        """This method helps in shifting the values to end of the second."""
+        return self.shift(seconds=count * 1,
+                          microseconds=-1)
+
+    def validate_frame(self, frame):
+        """Validates the given time frame."""
+        attrs = ['century',
+                 'decade',
+                 'year',
+                 'month',
+                 'day',
+                 'hour',
+                 'minute',
+                 'second']
+
+        if frame not in attrs:
+            raise ValueError('The given time frame {0} is invalid'
+                             .format(frame))
+
+    def start_of(self, frame):
+        """This method returns a floor value of datetime for the given time
+        frame.
+
+        Args:
+            frame (str): A time frame. Ex: year, month, day, minute, etc.
+
+        Returns:
+            zulu.Datetime.datetime
+        """
+        self.validate_frame(frame)
+        method = getattr(self, 'start_of_{0}'.format(frame), None)
+
+        return method()
+
+    def end_of(self, frame, count=1):
+        """This method returns a ceil value of datetime for the given time
+        frame.
+
+        Args:
+            frame (str): A time frame. Ex: year, month, day, minute, etc.
+            count (int): Number of frames to span
+
+        Returns:
+            zulu.Datetime.datetime
+        """
+        self.validate_frame(frame)
+        method = getattr(self, 'end_of_{0}'.format(frame), None)
+
+        return method(count=count)
+
+    def span(self, frame, count=1):
+        """Returns two new :class:`Datetime <datetime.datetime>` objects,
+        representing the time span of the :class:`Datetime <datetime.datetime>`
+         object in a given time frame.
+
+        Args:
+             frame (str): A time frame. Ex: year, month, day, minute, etc.
+             count (int): Number of frames to span
+
+        Returns:
+            floor: <datetime.datetime>
+            ceil: <datetime.datetime>
+        """
+        return (self.start_of(frame), self.end_of(frame, count))
+
     def __repr__(self):  # pragma: no cover
         """Return representation of :class:`.DateTime`."""
         return '<DateTime [{0}]>'.format(self.isoformat())


### PR DESCRIPTION
 - Added `zulu.Datetime.span`, `zulu.Datetime.start_of`, `zulu.Datetime.end_of` methods.
 - Supported units are: `century`, `decade`, `year`, `month`, `day`, `hour`, `minute`, `second`.
 - Added documentation for all the three methods.